### PR TITLE
Fix API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ src/
 
 ## 🌐 API
 
-Este projeto utiliza a [Elden Ring Fan API](https://docs.eldenring.fanapis.com/docs/):
+Este projeto utiliza a [Elden Ring Fan API](https://eldenring.fanapis.com/docs):
 - **📜 Classes**: `https://eldenring.fanapis.com/api/classes`
 - **⚔️ Armas**: `https://eldenring.fanapis.com/api/weapons`
 - **👹 Chefes**: `https://eldenring.fanapis.com/api/bosses`


### PR DESCRIPTION
## Summary
- correct the API docs URL in `README.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844c6e39a9883279b28e0958b1fc158