### PR TITLE
Add Ammo section

### DIFF
--- a/__tests__/useEldenRingAmmo.test.ts
+++ b/__tests__/useEldenRingAmmo.test.ts
@@ -1,0 +1,28 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEldenRingAmmo } from '@/hooks/useEldenRingAmmo';
+
+const mockAmmos = [
+  { id: 'a1', name: 'Arrow' },
+  { id: 'a2', name: 'Bolt' },
+];
+
+describe('useEldenRingAmmo', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: mockAmmos }),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns ammo data', async () => {
+    const { result } = renderHook(() => useEldenRingAmmo());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.ammos).toEqual(mockAmmos);
+  });
+});

--- a/src/app/ammo/page.tsx
+++ b/src/app/ammo/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { AmmoCard } from "@/components/AmmoCard";
+import { LoadingCard } from "@/components/LoadingCard";
+import { useEldenRingAmmo } from "@/hooks/useEldenRingAmmo";
+import { Input } from "@/components/ui/input";
+
+export default function AmmoPage() {
+  const [search, setSearch] = useState("");
+  const { ammos, loading, error } = useEldenRingAmmo(search);
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center -mt-20 pt-20">
+        <div className="text-center">
+          <h1 className="text-2xl font-medieval text-destructive mb-4">Error</h1>
+          <p className="text-muted-foreground">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background -mt-20 pt-20">
+      <div className="relative py-16 px-6">
+        <div className="absolute inset-0 bg-gradient-to-b from-background via-background/95 to-background/80" />
+        <div className="relative mx-auto max-w-7xl text-center">
+          <h1 className="font-medieval text-4xl md:text-6xl text-golden-light mb-4">
+            Ammunition Arsenal
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
+            Stock up on arrows, bolts and other deadly ammo for your journey.
+          </p>
+        </div>
+      </div>
+
+      <div className="px-6 pb-16">
+        <div className="mx-auto max-w-7xl">
+          <div className="mb-6">
+            <Input
+              placeholder="Search ammo..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="bg-background/50 border-border/50 focus:border-golden/50"
+            />
+          </div>
+          {loading ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <LoadingCard key={i} />
+              ))}
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {ammos.map((ammo) => (
+                <AmmoCard key={ammo.id} ammo={ammo} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -90,6 +90,25 @@ export default function Home() {
               </CardContent>
             </Card>
 
+            <Card className="border-border/50 bg-card/80 backdrop-blur-sm hover:border-golden/30 transition-all duration-300">
+              <CardHeader>
+                <CardTitle className="font-medieval text-golden-light">Ammo</CardTitle>
+                <CardDescription>
+                  Bolts, arrows and all ammunition for your weapons.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground mb-4">
+                  Prepare for battle with a variety of ammunition types.
+                </p>
+                <Link href="/ammo">
+                  <Button className="w-full bg-golden hover:bg-golden-dark text-background">
+                    View Ammo
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+
             <Card className="border-border/50 bg-card/80 backdrop-blur-sm opacity-60">
               <CardHeader>
                 <CardTitle className="font-medieval text-muted-foreground">Bosses</CardTitle>

--- a/src/components/AmmoCard.tsx
+++ b/src/components/AmmoCard.tsx
@@ -1,0 +1,66 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EldenRingAmmo } from "@/lib/types";
+import Image from "next/image";
+
+interface AmmoCardProps {
+  ammo: EldenRingAmmo;
+}
+
+export function AmmoCard({ ammo }: AmmoCardProps) {
+  const { name, image, description, type, attackPower, passive } = ammo;
+
+  return (
+    <Card className="group overflow-hidden border-border/50 bg-card/80 backdrop-blur-sm transition-all duration-300 hover:border-golden/50 hover:bg-card/90 hover:shadow-lg hover:shadow-golden/20">
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <Image
+          src={image}
+          alt={name}
+          fill
+          className="object-contain transition-transform duration-300 group-hover:scale-105 p-4"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-transparent to-transparent" />
+        <div className="absolute top-2 left-2">
+          <Badge className="bg-golden text-background font-mono text-xs">{type}</Badge>
+        </div>
+      </div>
+
+      <CardHeader className="pb-3">
+        <CardTitle className="font-medieval text-lg text-golden-light group-hover:text-golden transition-colors line-clamp-1">
+          {name}
+        </CardTitle>
+        <CardDescription className="text-muted-foreground leading-relaxed text-sm line-clamp-2">
+          {description}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="pt-0 space-y-3">
+        {attackPower.length > 0 && (
+          <div>
+            <h4 className="text-xs font-semibold text-muted-foreground mb-2">POWER</h4>
+            <div className="flex gap-1 flex-wrap">
+              {attackPower.map((atk, index) => (
+                <Badge
+                  key={index}
+                  variant="outline"
+                  className="bg-muted/50 text-foreground text-xs font-mono"
+                >
+                  {atk.name}: {atk.amount}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+        {passive && passive !== "-" && (
+          <div>
+            <h4 className="text-xs font-semibold text-muted-foreground mb-2">PASSIVE</h4>
+            <Badge variant="outline" className="bg-muted/50 text-foreground text-xs font-mono">
+              {passive}
+            </Badge>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,6 +23,11 @@ export function Navigation() {
                   Weapons
                 </Button>
               </Link>
+              <Link href="/ammo">
+                <Button variant="ghost" className="text-foreground hover:text-golden hover:bg-golden/10">
+                  Ammo
+                </Button>
+              </Link>
               <Button variant="ghost" disabled className="text-muted-foreground">
                 Bosses
               </Button>

--- a/src/hooks/useEldenRingAPI.ts
+++ b/src/hooks/useEldenRingAPI.ts
@@ -6,7 +6,10 @@ interface UseApiResult<T> {
   error: string | null;
 }
 
-export function useEldenRingAPI<T>(endpoint: string): UseApiResult<T> {
+export function useEldenRingAPI<T>(
+  endpoint: string,
+  params: Record<string, string> = {}
+): UseApiResult<T> {
   const [data, setData] = useState<T[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -16,8 +19,15 @@ export function useEldenRingAPI<T>(endpoint: string): UseApiResult<T> {
       try {
         setLoading(true);
         setError(null);
-        
-        const response = await fetch(`https://eldenring.fanapis.com/api/${endpoint}`);
+
+        const url = new URL(
+          `https://eldenring.fanapis.com/api/${endpoint}`
+        );
+        Object.entries(params).forEach(([key, value]) => {
+          url.searchParams.append(key, value);
+        });
+
+        const response = await fetch(url.toString());
         
         if (!response.ok) {
           throw new Error(`Failed to fetch ${endpoint}`);
@@ -38,7 +48,7 @@ export function useEldenRingAPI<T>(endpoint: string): UseApiResult<T> {
     };
 
     fetchData();
-  }, [endpoint]);
+  }, [endpoint, JSON.stringify(params)]);
 
   return { data, loading, error };
 } 

--- a/src/hooks/useEldenRingAmmo.ts
+++ b/src/hooks/useEldenRingAmmo.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from "react";
+import { EldenRingAmmo } from "@/lib/types";
+
+interface UseAmmoResult {
+  ammos: EldenRingAmmo[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useEldenRingAmmo(search: string = ""): UseAmmoResult {
+  const [ammos, setAmmos] = useState<EldenRingAmmo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchAmmos = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const url = new URL("https://eldenring.fanapis.com/api/ammos");
+        url.searchParams.set("limit", "1000");
+        if (search) {
+          url.searchParams.set("name", search);
+        }
+        const response = await fetch(url.toString());
+        if (!response.ok) {
+          throw new Error("Failed to fetch ammos");
+        }
+        const result = await response.json();
+        if (result.success && result.data) {
+          setAmmos(result.data);
+        } else {
+          throw new Error("Invalid response format for ammos");
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An error occurred");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAmmos();
+  }, [search]);
+
+  return { ammos, loading, error };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,21 @@ export interface EldenRingWeapon {
 
 export type EldenRingWeaponsResponse = EldenRingApiResponse<EldenRingWeapon>;
 
+export interface EldenRingAmmo {
+  id: string;
+  name: string;
+  image: string;
+  description: string;
+  type: string;
+  attackPower: Array<{
+    name: string;
+    amount: number;
+  }>;
+  passive: string;
+}
+
+export type EldenRingAmmoResponse = EldenRingApiResponse<EldenRingAmmo>;
+
 export interface PaginationInfo {
   currentPage: number;
   totalItems: number;


### PR DESCRIPTION
## Summary
- extend api hook to accept params
- implement AmmoCard component
- add Ammo page with search
- link Ammo in navigation and homepage
- create useEldenRingAmmo hook
- add tests for ammo hook

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844d607ad948327b2ce55a12dbaf5e0