### PR TITLE
Add Ashes of War section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Um site elegante e responsivo dedicado ao universo de **Elden Ring**, construíd
   - Paginação com 16 armas por página
   - Cards detalhados com poder de ataque, scaling, requisitos e peso
   - Categorias e graus de scaling com código de cores
+- **🔥 Ashes of War**: Lista completa de cinzas com afinidade e skill
 - **🌓 Dark/Light Mode**: Sistema completo de alternância de tema
   - Toggle na navegação superior direita
   - Persistência da preferência no localStorage

--- a/__tests__/useEldenRingAPI.test.ts
+++ b/__tests__/useEldenRingAPI.test.ts
@@ -1,0 +1,26 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEldenRingAPI } from '@/hooks/useEldenRingAPI';
+
+describe('useEldenRingAPI', () => {
+  const mockData = [{ id: 'a1', name: 'Ash' }];
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: mockData }),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('fetches data from the provided endpoint', async () => {
+    const { result } = renderHook(() => useEldenRingAPI('ashes'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual(mockData);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/app/ashes/page.tsx
+++ b/src/app/ashes/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { AshCard } from "@/components/AshCard";
+import { LoadingCard } from "@/components/LoadingCard";
+import { EldenRingAsh } from "@/lib/types";
+import { useEldenRingAPI } from "@/hooks/useEldenRingAPI";
+
+export default function AshesPage() {
+  const { data: ashes, loading, error } = useEldenRingAPI<EldenRingAsh>("ashes");
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center -mt-20 pt-20">
+        <div className="text-center">
+          <h1 className="text-2xl font-medieval text-destructive mb-4">Error</h1>
+          <p className="text-muted-foreground">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background -mt-20 pt-20">
+      {/* Header */}
+      <div className="relative py-16 px-6">
+        <div className="absolute inset-0 bg-gradient-to-b from-background via-background/95 to-background/80" />
+        <div className="relative mx-auto max-w-7xl text-center">
+          <h1 className="font-medieval text-4xl md:text-6xl text-golden-light mb-4">Ashes of War</h1>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
+            Imbue your weapons with powerful skills and affinities to change the tide of battle.
+          </p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="px-6 pb-16">
+        <div className="mx-auto max-w-7xl">
+          {loading ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <LoadingCard key={i} />
+              ))}
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {ashes.map((ash) => (
+                <AshCard key={ash.id} ash={ash} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AshCard.tsx
+++ b/src/components/AshCard.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EldenRingAsh } from "@/lib/types";
+import Image from "next/image";
+
+interface AshCardProps {
+  ash: EldenRingAsh;
+}
+
+export function AshCard({ ash }: AshCardProps) {
+  const { name, image, description, affinity, skill } = ash;
+  return (
+    <Card className="group overflow-hidden border-border/50 bg-card/80 backdrop-blur-sm transition-all duration-300 hover:border-golden/50 hover:bg-card/90 hover:shadow-lg hover:shadow-golden/20">
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <Image
+          src={image}
+          alt={name}
+          fill
+          className="object-contain transition-transform duration-300 group-hover:scale-105 p-4"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-transparent to-transparent" />
+        <div className="absolute bottom-2 left-2">
+          <Badge className="bg-background/80 text-foreground font-mono text-xs">
+            {affinity}
+          </Badge>
+        </div>
+      </div>
+      <CardHeader className="pb-3">
+        <CardTitle className="font-medieval text-lg text-golden-light group-hover:text-golden transition-colors line-clamp-1">
+          {name}
+        </CardTitle>
+        <CardDescription className="text-muted-foreground leading-relaxed text-sm line-clamp-2">
+          {description}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="pt-0">
+        {skill && (
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">Skill</span>
+            <Badge variant="outline" className="bg-muted/50 text-foreground text-xs font-mono">
+              {skill}
+            </Badge>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,6 +23,11 @@ export function Navigation() {
                   Weapons
                 </Button>
               </Link>
+              <Link href="/ashes">
+                <Button variant="ghost" className="text-foreground hover:text-golden hover:bg-golden/10">
+                  Ashes
+                </Button>
+              </Link>
               <Button variant="ghost" disabled className="text-muted-foreground">
                 Bosses
               </Button>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,17 @@ export interface EldenRingWeapon {
 
 export type EldenRingWeaponsResponse = EldenRingApiResponse<EldenRingWeapon>;
 
+export interface EldenRingAsh {
+  id: string;
+  name: string;
+  image: string;
+  description: string;
+  affinity: string;
+  skill: string;
+}
+
+export type EldenRingAshesResponse = EldenRingApiResponse<EldenRingAsh>;
+
 export interface PaginationInfo {
   currentPage: number;
   totalItems: number;


### PR DESCRIPTION
## Summary
- add Ashes of War page
- add AshCard component
- extend data types for ashes
- link Ashes page in navigation
- document Ashes section in README
- add hook test for useEldenRingAPI

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844d6a861a88327809fd877e95273dc