### PR TITLE
Add incantations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Um site elegante e responsivo dedicado ao universo de **Elden Ring**, construíd
   - Paginação com 16 armas por página
   - Cards detalhados com poder de ataque, scaling, requisitos e peso
   - Categorias e graus de scaling com código de cores
+- **🙏 Incantations**: Milagres e encantamentos para aprimorar sua jornada
+  - Busca por nome do feitiço
+  - Paginação com 16 resultados por página
 - **🌓 Dark/Light Mode**: Sistema completo de alternância de tema
   - Toggle na navegação superior direita
   - Persistência da preferência no localStorage
@@ -65,6 +68,7 @@ src/
 ├── app/                    # App Router do Next.js
 │   ├── classes/           # Página das classes
 │   ├── weapons/           # Página das armas
+│   ├── incantations/      # Página das incantações
 │   ├── globals.css        # Estilos globais
 │   ├── layout.tsx         # Layout raiz
 │   └── page.tsx          # Página inicial
@@ -72,7 +76,9 @@ src/
 │   ├── ui/               # Componentes shadcn/ui
 │   ├── ClassCard.tsx     # Card das classes
 │   ├── WeaponCard.tsx    # Card das armas
+│   ├── IncantationCard.tsx # Card das incantações
 │   ├── WeaponsFilters.tsx # Filtros das armas
+│   ├── IncantationsFilters.tsx # Filtros das incantações
 │   ├── WeaponsPagination.tsx # Paginação das armas
 │   ├── LoadingCard.tsx   # Card de loading
 │   └── Navigation.tsx    # Navegação principal
@@ -101,6 +107,7 @@ src/
 Este projeto utiliza a [Elden Ring Fan API](https://eldenring.fanapis.com/docs):
 - **📜 Classes**: `https://eldenring.fanapis.com/api/classes`
 - **⚔️ Armas**: `https://eldenring.fanapis.com/api/weapons`
+- **🙏 Incantations**: `https://eldenring.fanapis.com/api/incantations`
 - **👹 Chefes**: `https://eldenring.fanapis.com/api/bosses`
 
 ## 📝 Scripts Disponíveis

--- a/__tests__/useEldenRingIncantations.test.ts
+++ b/__tests__/useEldenRingIncantations.test.ts
@@ -1,0 +1,33 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEldenRingIncantations } from '@/hooks/useEldenRingIncantations';
+
+const mockIncantations = [
+  { id: 'i1', name: 'Fire', image: '', description: '', type: 'Incantation', cost: 10, slots: 1, effects: '', requires: [] }
+];
+
+describe('useEldenRingIncantations', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: mockIncantations, total: 1 }),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('fetches and returns incantations data', async () => {
+    const { result } = renderHook(() => useEldenRingIncantations({ page: 0, limit: 10 }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.incantations).toEqual(mockIncantations);
+    expect(result.current.pagination).toEqual({
+      currentPage: 1,
+      totalItems: 1,
+      itemsPerPage: 10,
+      totalPages: 1,
+    });
+  });
+});

--- a/src/app/incantations/page.tsx
+++ b/src/app/incantations/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { IncantationCard } from "@/components/IncantationCard";
+import { LoadingCard } from "@/components/LoadingCard";
+import { IncantationsFilters } from "@/components/IncantationsFilters";
+import { WeaponsPagination } from "@/components/WeaponsPagination";
+import { useEldenRingIncantations } from "@/hooks/useEldenRingIncantations";
+
+export default function IncantationsPage() {
+  const [page, setPage] = useState(0);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(0);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const { incantations, loading, error, pagination } = useEldenRingIncantations({
+    page,
+    limit: 16,
+    search: debouncedSearch || undefined,
+  });
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage - 1);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center -mt-20 pt-20">
+        <div className="text-center">
+          <h1 className="text-2xl font-medieval text-destructive mb-4">Error</h1>
+          <p className="text-muted-foreground">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background -mt-20 pt-20">
+      <div className="relative py-16 px-6">
+        <div className="absolute inset-0 bg-gradient-to-b from-background via-background/95 to-background/80" />
+        <div className="relative mx-auto max-w-7xl text-center">
+          <h1 className="font-medieval text-4xl md:text-6xl text-golden-light mb-4">
+            Sacred Incantations
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
+            Harness the power of faith to unleash miraculous spells upon your foes.
+          </p>
+        </div>
+      </div>
+
+      <div className="px-6 pb-16">
+        <div className="mx-auto max-w-7xl">
+          <IncantationsFilters
+            search={search}
+            setSearch={setSearch}
+            totalItems={pagination.totalItems}
+          />
+
+          {loading ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {Array.from({ length: 16 }).map((_, i) => (
+                <LoadingCard key={i} />
+              ))}
+            </div>
+          ) : incantations.length === 0 ? (
+            <div className="text-center py-16">
+              <h3 className="text-xl font-medieval text-muted-foreground mb-2">
+                No incantations found
+              </h3>
+              <p className="text-muted-foreground">
+                Try adjusting your search criteria.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {incantations.map((inc) => (
+                  <IncantationCard key={inc.id} incantation={inc} />
+                ))}
+              </div>
+              <WeaponsPagination
+                pagination={pagination}
+                onPageChange={handlePageChange}
+                loading={loading}
+                itemLabel="incantations"
+              />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/IncantationCard.tsx
+++ b/src/components/IncantationCard.tsx
@@ -1,0 +1,69 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EldenRingIncantation } from "@/lib/types";
+import Image from "next/image";
+
+interface IncantationCardProps {
+  incantation: EldenRingIncantation;
+}
+
+export function IncantationCard({ incantation }: IncantationCardProps) {
+  const { name, image, description, cost, slots, effects, requires } = incantation;
+
+  return (
+    <Card className="group overflow-hidden border-border/50 bg-card/80 backdrop-blur-sm transition-all duration-300 hover:border-golden/50 hover:bg-card/90 hover:shadow-lg hover:shadow-golden/20">
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <Image
+          src={image}
+          alt={name}
+          fill
+          className="object-contain transition-transform duration-300 group-hover:scale-105 p-4"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-transparent to-transparent" />
+        <div className="absolute bottom-2 left-2 flex gap-2">
+          <Badge className="bg-golden text-background font-bold">
+            {cost} FP
+          </Badge>
+          <Badge variant="outline" className="bg-background/80 text-foreground font-mono text-xs">
+            {slots} slot{slots > 1 ? "s" : ""}
+          </Badge>
+        </div>
+      </div>
+
+      <CardHeader className="pb-3">
+        <CardTitle className="font-medieval text-lg text-golden-light group-hover:text-golden transition-colors line-clamp-1">
+          {name}
+        </CardTitle>
+        <CardDescription className="text-muted-foreground leading-relaxed text-sm line-clamp-2">
+          {description}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="pt-0 space-y-3">
+        {effects && (
+          <div>
+            <h4 className="text-xs font-semibold text-muted-foreground mb-2">EFFECT</h4>
+            <p className="text-sm text-muted-foreground line-clamp-2">{effects}</p>
+          </div>
+        )}
+        {requires.length > 0 && (
+          <div>
+            <h4 className="text-xs font-semibold text-muted-foreground mb-2">REQUIRES</h4>
+            <div className="flex gap-1 flex-wrap">
+              {requires.map((req, index) => (
+                <Badge
+                  key={index}
+                  variant="outline"
+                  className="bg-muted/50 text-foreground text-xs font-mono"
+                >
+                  {req.name}: {req.amount}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/IncantationsFilters.tsx
+++ b/src/components/IncantationsFilters.tsx
@@ -1,0 +1,28 @@
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+
+interface IncantationsFiltersProps {
+  search: string;
+  setSearch: (search: string) => void;
+  totalItems: number;
+}
+
+export function IncantationsFilters({ search, setSearch, totalItems }: IncantationsFiltersProps) {
+  return (
+    <div className="flex flex-col sm:flex-row gap-4 mb-6">
+      <div className="flex-1">
+        <Input
+          placeholder="Search incantations..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="bg-background/50 border-border/50 focus:border-golden/50"
+        />
+      </div>
+      <div className="flex items-center">
+        <Badge variant="outline" className="bg-muted/50 text-foreground">
+          {totalItems} incantations
+        </Badge>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,6 +23,11 @@ export function Navigation() {
                   Weapons
                 </Button>
               </Link>
+              <Link href="/incantations">
+                <Button variant="ghost" className="text-foreground hover:text-golden hover:bg-golden/10">
+                  Incantations
+                </Button>
+              </Link>
               <Button variant="ghost" disabled className="text-muted-foreground">
                 Bosses
               </Button>

--- a/src/components/WeaponsPagination.tsx
+++ b/src/components/WeaponsPagination.tsx
@@ -6,12 +6,14 @@ interface WeaponsPaginationProps {
   pagination: PaginationInfo;
   onPageChange: (page: number) => void;
   loading: boolean;
+  itemLabel?: string;
 }
 
-export function WeaponsPagination({ 
-  pagination, 
-  onPageChange, 
-  loading 
+export function WeaponsPagination({
+  pagination,
+  onPageChange,
+  loading,
+  itemLabel = "weapons",
 }: WeaponsPaginationProps) {
   const { currentPage, totalPages, totalItems, itemsPerPage } = pagination;
   
@@ -43,7 +45,7 @@ export function WeaponsPagination({
   return (
     <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mt-8">
       <div className="text-sm text-muted-foreground">
-        Showing {startItem}-{endItem} of {totalItems} weapons
+        Showing {startItem}-{endItem} of {totalItems} {itemLabel}
       </div>
       
       <div className="flex items-center gap-2">

--- a/src/hooks/useEldenRingIncantations.ts
+++ b/src/hooks/useEldenRingIncantations.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect } from "react";
+import { EldenRingIncantation, PaginationInfo } from "@/lib/types";
+
+interface UseIncantationsResult {
+  incantations: EldenRingIncantation[];
+  loading: boolean;
+  error: string | null;
+  pagination: PaginationInfo;
+}
+
+interface UseIncantationsParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+}
+
+export function useEldenRingIncantations(
+  params: UseIncantationsParams = {}
+): UseIncantationsResult {
+  const [incantations, setIncantations] = useState<EldenRingIncantation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState<PaginationInfo>({
+    currentPage: 1,
+    totalItems: 0,
+    itemsPerPage: params.limit ?? 20,
+    totalPages: 0,
+  });
+
+  const { page = 0, limit = 20, search } = params;
+
+  useEffect(() => {
+    const fetchIncantations = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const query = new URLSearchParams({
+          limit: limit.toString(),
+          page: page.toString(),
+        });
+        if (search) query.append("name", search);
+        const res = await fetch(
+          `https://eldenring.fanapis.com/api/incantations?${query}`
+        );
+        if (!res.ok) {
+          throw new Error("Failed to fetch incantations");
+        }
+        const data = await res.json();
+        if (data.success && data.data) {
+          setIncantations(data.data);
+          const total = data.total || data.count;
+          setPagination({
+            currentPage: page + 1,
+            totalItems: total,
+            itemsPerPage: limit,
+            totalPages: Math.ceil(total / limit),
+          });
+        } else {
+          throw new Error("Invalid response format");
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An error occurred");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchIncantations();
+  }, [page, limit, search]);
+
+  return { incantations, loading, error, pagination };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,23 @@ export interface EldenRingWeapon {
 
 export type EldenRingWeaponsResponse = EldenRingApiResponse<EldenRingWeapon>;
 
+export interface EldenRingIncantation {
+  id: string;
+  name: string;
+  image: string;
+  description: string;
+  type: string;
+  cost: number;
+  slots: number;
+  effects: string;
+  requires: Array<{
+    name: string;
+    amount: number;
+  }>;
+}
+
+export type EldenRingIncantationsResponse = EldenRingApiResponse<EldenRingIncantation>;
+
 export interface PaginationInfo {
   currentPage: number;
   totalItems: number;


### PR DESCRIPTION
## Summary
- implement `useEldenRingIncantations` hook to fetch paged data
- display incantations with cards and search filters
- reuse pagination with a customizable label
- add navigation link and update project docs
- test the new hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d6c69a5c832797d6f11e621ae7cf