### PR TITLE
Add items page

### DIFF
--- a/__tests__/useEldenRingItems.test.ts
+++ b/__tests__/useEldenRingItems.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEldenRingAPI } from '@/hooks/useEldenRingAPI';
+import { EldenRingItem } from '@/lib/types';
+
+const mockItems: EldenRingItem[] = [
+  { id: 'i1', name: 'Item 1', image: '', description: '', type: 'Reusable', effect: 'Effect' },
+  { id: 'i2', name: 'Item 2', image: '', description: '', type: 'Key Item', effect: 'Effect' },
+];
+
+describe('useEldenRingAPI - items', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: mockItems }),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('fetches items data', async () => {
+    const { result } = renderHook(() => useEldenRingAPI<EldenRingItem>('items'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual(mockItems);
+  });
+});

--- a/src/app/items/page.tsx
+++ b/src/app/items/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { ItemCard } from "@/components/ItemCard";
+import { LoadingCard } from "@/components/LoadingCard";
+import { EldenRingItem } from "@/lib/types";
+import { useEldenRingAPI } from "@/hooks/useEldenRingAPI";
+
+export default function ItemsPage() {
+  const { data: items, loading, error } = useEldenRingAPI<EldenRingItem>("items");
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center -mt-20 pt-20">
+        <div className="text-center">
+          <h1 className="text-2xl font-medieval text-destructive mb-4">Error</h1>
+          <p className="text-muted-foreground">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background -mt-20 pt-20">
+      {/* Header */}
+      <div className="relative py-16 px-6">
+        <div className="absolute inset-0 bg-gradient-to-b from-background via-background/95 to-background/80" />
+        <div className="relative mx-auto max-w-7xl text-center">
+          <h1 className="font-medieval text-4xl md:text-6xl text-golden-light mb-4">
+            Items of The Lands Between
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
+            Explore consumables and key items that aid your journey.
+          </p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="px-6 pb-16">
+        <div className="mx-auto max-w-7xl">
+          {loading ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <LoadingCard key={i} />
+              ))}
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {items.map((item) => (
+                <ItemCard key={item.id} item={item} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -90,6 +90,23 @@ export default function Home() {
               </CardContent>
             </Card>
 
+            <Card className="border-border/50 bg-card/80 backdrop-blur-sm hover:border-golden/30 transition-all duration-300">
+              <CardHeader>
+                <CardTitle className="font-medieval text-golden-light">Items</CardTitle>
+                <CardDescription>Consumables and key items for every Tarnished.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground mb-4">
+                  Discover talismans, craftables and various items to aid you in your quest.
+                </p>
+                <Link href="/items">
+                  <Button className="w-full bg-golden hover:bg-golden-dark text-background">
+                    View Items
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+
             <Card className="border-border/50 bg-card/80 backdrop-blur-sm opacity-60">
               <CardHeader>
                 <CardTitle className="font-medieval text-muted-foreground">Bosses</CardTitle>

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -1,0 +1,45 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EldenRingItem } from "@/lib/types";
+import Image from "next/image";
+
+interface ItemCardProps {
+  item: EldenRingItem;
+}
+
+export function ItemCard({ item }: ItemCardProps) {
+  const { name, image, description, type, effect } = item;
+
+  return (
+    <Card className="group overflow-hidden border-border/50 bg-card/80 backdrop-blur-sm transition-all duration-300 hover:border-golden/50 hover:bg-card/90 hover:shadow-lg hover:shadow-golden/20">
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <Image
+          src={image}
+          alt={name}
+          fill
+          className="object-contain transition-transform duration-300 group-hover:scale-105 p-4"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-transparent to-transparent" />
+        <div className="absolute top-2 left-2">
+          <Badge variant="outline" className="bg-muted/50 text-foreground text-xs font-mono">
+            {type}
+          </Badge>
+        </div>
+      </div>
+
+      <CardHeader className="pb-3">
+        <CardTitle className="font-medieval text-lg text-golden-light group-hover:text-golden transition-colors line-clamp-1">
+          {name}
+        </CardTitle>
+        <CardDescription className="text-muted-foreground leading-relaxed text-sm line-clamp-2">
+          {description}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="pt-0 text-sm text-muted-foreground line-clamp-2">
+        {effect}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,6 +23,11 @@ export function Navigation() {
                   Weapons
                 </Button>
               </Link>
+              <Link href="/items">
+                <Button variant="ghost" className="text-foreground hover:text-golden hover:bg-golden/10">
+                  Items
+                </Button>
+              </Link>
               <Button variant="ghost" disabled className="text-muted-foreground">
                 Bosses
               </Button>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,6 +49,15 @@ export interface EldenRingWeapon {
   weight: number;
 }
 
+export interface EldenRingItem {
+  id: string;
+  name: string;
+  image: string;
+  description: string;
+  type: string;
+  effect: string;
+}
+
 export type EldenRingWeaponsResponse = EldenRingApiResponse<EldenRingWeapon>;
 
 export interface PaginationInfo {


### PR DESCRIPTION
## Summary
- add `EldenRingItem` type
- create `ItemCard` component to show items
- implement `/items` page using fan API
- link Items in navigation and on homepage
- test `useEldenRingAPI` for items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d6cc8de883279321d9316d618bba