### PR TITLE
Add Locations section

### DIFF
--- a/__tests__/useEldenRingAPI.test.ts
+++ b/__tests__/useEldenRingAPI.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEldenRingAPI } from '@/hooks/useEldenRingAPI';
+import { EldenRingLocation } from '@/lib/types';
+
+const mockLocations: EldenRingLocation[] = [
+  { id: 'loc1', name: 'Stormveil Castle', image: 'img.png', region: 'Limgrave', description: 'test' },
+];
+
+describe('useEldenRingAPI - locations', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: mockLocations }),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('fetches locations data', async () => {
+    const { result } = renderHook(() => useEldenRingAPI<EldenRingLocation>('locations'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual(mockLocations);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { LocationCard } from "@/components/LocationCard";
+import { LoadingCard } from "@/components/LoadingCard";
+import { EldenRingLocation } from "@/lib/types";
+import { useEldenRingAPI } from "@/hooks/useEldenRingAPI";
+
+export default function LocationsPage() {
+  const { data: locations, loading, error } = useEldenRingAPI<EldenRingLocation>("locations");
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center -mt-20 pt-20">
+        <div className="text-center">
+          <h1 className="text-2xl font-medieval text-destructive mb-4">Error</h1>
+          <p className="text-muted-foreground">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background -mt-20 pt-20">
+      <div className="relative py-16 px-6">
+        <div className="absolute inset-0 bg-gradient-to-b from-background via-background/95 to-background/80" />
+        <div className="relative mx-auto max-w-7xl text-center">
+          <h1 className="font-medieval text-4xl md:text-6xl text-golden-light mb-4">Landmarks of The Lands Between</h1>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
+            Journey across the vast world and discover castles, dungeons and other key locations.
+          </p>
+        </div>
+      </div>
+
+      <div className="px-6 pb-16">
+        <div className="mx-auto max-w-7xl">
+          {loading ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <LoadingCard key={i} />
+              ))}
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {locations.map((loc) => (
+                <LocationCard key={loc.id} location={loc} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -90,6 +90,25 @@ export default function Home() {
               </CardContent>
             </Card>
 
+            <Card className="border-border/50 bg-card/80 backdrop-blur-sm hover:border-golden/30 transition-all duration-300">
+              <CardHeader>
+                <CardTitle className="font-medieval text-golden-light">Locations</CardTitle>
+                <CardDescription>
+                  Key places scattered throughout the realms.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground mb-4">
+                  Venture across castles, dungeons and landmarks that shape your journey.
+                </p>
+                <Link href="/locations">
+                  <Button className="w-full bg-golden hover:bg-golden-dark text-background">
+                    View Locations
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+
             <Card className="border-border/50 bg-card/80 backdrop-blur-sm opacity-60">
               <CardHeader>
                 <CardTitle className="font-medieval text-muted-foreground">Bosses</CardTitle>

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -1,0 +1,42 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EldenRingLocation } from "@/lib/types";
+import Image from "next/image";
+
+interface LocationCardProps {
+  location: EldenRingLocation;
+}
+
+export function LocationCard({ location }: LocationCardProps) {
+  const { name, image, description, region } = location;
+
+  return (
+    <Card className="group overflow-hidden border-border/50 bg-card/80 backdrop-blur-sm transition-all duration-300 hover:border-golden/50 hover:bg-card/90 hover:shadow-lg hover:shadow-golden/20">
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <Image
+          src={image}
+          alt={name}
+          fill
+          className="object-cover transition-transform duration-300 group-hover:scale-105"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-transparent to-transparent" />
+        <div className="absolute bottom-4 left-4">
+          <Badge className="bg-golden text-background font-medieval font-semibold">
+            {region}
+          </Badge>
+        </div>
+      </div>
+
+      <CardHeader className="pb-3">
+        <CardTitle className="font-medieval text-xl text-golden-light group-hover:text-golden transition-colors">
+          {name}
+        </CardTitle>
+        <CardDescription className="text-muted-foreground leading-relaxed line-clamp-3">
+          {description}
+        </CardDescription>
+      </CardHeader>
+      <CardContent />
+    </Card>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,6 +23,11 @@ export function Navigation() {
                   Weapons
                 </Button>
               </Link>
+              <Link href="/locations">
+                <Button variant="ghost" className="text-foreground hover:text-golden hover:bg-golden/10">
+                  Locations
+                </Button>
+              </Link>
               <Button variant="ghost" disabled className="text-muted-foreground">
                 Bosses
               </Button>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,16 @@ export interface EldenRingWeapon {
 
 export type EldenRingWeaponsResponse = EldenRingApiResponse<EldenRingWeapon>;
 
+export interface EldenRingLocation {
+  id: string;
+  name: string;
+  image: string;
+  region: string;
+  description: string;
+}
+
+export type EldenRingLocationsResponse = EldenRingApiResponse<EldenRingLocation>;
+
 export interface PaginationInfo {
   currentPage: number;
   totalItems: number;


### PR DESCRIPTION
## Summary
- expand API types with `EldenRingLocation`
- add new `LocationCard` component for displaying location info
- create `/locations` page to list locations from the Elden Ring API
- expose Locations in navigation and on the homepage
- test `useEldenRingAPI` when fetching locations

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844d6d6d0f48327bcfabb28a9de5ba6