### PR TITLE
Add NPCs section with hooks and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Um site elegante e responsivo dedicado ao universo de **Elden Ring**, construíd
   - Paginação com 16 armas por página
   - Cards detalhados com poder de ataque, scaling, requisitos e peso
   - Categorias e graus de scaling com código de cores
+- **🧑‍🤝‍🧑 NPCs**: Encontre comerciantes e aliados
+  - Busca por nome do NPC
+  - Paginação com 16 NPCs por página
 - **🌓 Dark/Light Mode**: Sistema completo de alternância de tema
   - Toggle na navegação superior direita
   - Persistência da preferência no localStorage
@@ -74,11 +77,15 @@ src/
 │   ├── WeaponCard.tsx    # Card das armas
 │   ├── WeaponsFilters.tsx # Filtros das armas
 │   ├── WeaponsPagination.tsx # Paginação das armas
+│   ├── NPCCard.tsx       # Card dos NPCs
+│   ├── NpcsFilters.tsx   # Filtros dos NPCs
+│   ├── NpcsPagination.tsx # Paginação dos NPCs
 │   ├── LoadingCard.tsx   # Card de loading
 │   └── Navigation.tsx    # Navegação principal
 ├── hooks/                # Hooks customizados
-│   ├── useEldenRingAPI.ts # Hook da API (classes)
-│   └── useEldenRingWeapons.ts # Hook da API (armas)
+│   ├── useEldenRingAPI.ts   # Hook da API (classes)
+│   ├── useEldenRingWeapons.ts # Hook da API (armas)
+│   └── useEldenRingNPCs.ts   # Hook da API (npcs)
 └── lib/                  # Utilitários
     ├── types.ts          # Tipos TypeScript
     └── utils.ts          # Funções utilitárias
@@ -101,6 +108,7 @@ src/
 Este projeto utiliza a [Elden Ring Fan API](https://eldenring.fanapis.com/docs):
 - **📜 Classes**: `https://eldenring.fanapis.com/api/classes`
 - **⚔️ Armas**: `https://eldenring.fanapis.com/api/weapons`
+- **🧑‍🤝‍🧑 NPCs**: `https://eldenring.fanapis.com/api/npcs`
 - **👹 Chefes**: `https://eldenring.fanapis.com/api/bosses`
 
 ## 📝 Scripts Disponíveis

--- a/__tests__/useEldenRingNPCs.test.ts
+++ b/__tests__/useEldenRingNPCs.test.ts
@@ -1,0 +1,34 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEldenRingNPCs } from '@/hooks/useEldenRingNPCs';
+
+const mockNPCs = [
+  { id: 'n1', name: 'NPC 1' },
+  { id: 'n2', name: 'NPC 2' },
+];
+
+describe('useEldenRingNPCs', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: mockNPCs, total: 4 }),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns paginated NPC data', async () => {
+    const { result } = renderHook(() => useEldenRingNPCs({ page: 1, limit: 2 }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.npcs).toEqual(mockNPCs);
+    expect(result.current.pagination).toEqual({
+      currentPage: 2,
+      totalItems: 4,
+      itemsPerPage: 2,
+      totalPages: 2,
+    });
+  });
+});

--- a/src/app/npcs/page.tsx
+++ b/src/app/npcs/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { NPCCard } from "@/components/NPCCard";
+import { LoadingCard } from "@/components/LoadingCard";
+import { NpcsFilters } from "@/components/NpcsFilters";
+import { NpcsPagination } from "@/components/NpcsPagination";
+import { useEldenRingNPCs } from "@/hooks/useEldenRingNPCs";
+
+export default function NpcsPage() {
+  const [page, setPage] = useState(0);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(0); // reset when searching
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const { npcs, loading, error, pagination } = useEldenRingNPCs({
+    page,
+    limit: 16,
+    search: debouncedSearch || undefined,
+  });
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage - 1); // convert to 0-based
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center -mt-20 pt-20">
+        <div className="text-center">
+          <h1 className="text-2xl font-medieval text-destructive mb-4">Error</h1>
+          <p className="text-muted-foreground">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background -mt-20 pt-20">
+      {/* Header */}
+      <div className="relative py-16 px-6">
+        <div className="absolute inset-0 bg-gradient-to-b from-background via-background/95 to-background/80" />
+        <div className="relative mx-auto max-w-7xl text-center">
+          <h1 className="font-medieval text-4xl md:text-6xl text-golden-light mb-4">Faces of The Lands Between</h1>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
+            Meet the many allies and adversaries encountered throughout your journey.
+          </p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="px-6 pb-16">
+        <div className="mx-auto max-w-7xl">
+          <NpcsFilters search={search} setSearch={setSearch} totalItems={pagination.totalItems} />
+
+          {loading ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {Array.from({ length: 16 }).map((_, i) => (
+                <LoadingCard key={i} />
+              ))}
+            </div>
+          ) : npcs.length === 0 ? (
+            <div className="text-center py-16">
+              <h3 className="text-xl font-medieval text-muted-foreground mb-2">No NPCs found</h3>
+              <p className="text-muted-foreground">Try adjusting your search.</p>
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {npcs.map((npc) => (
+                  <NPCCard key={npc.id} npc={npc} />
+                ))}
+              </div>
+
+              <NpcsPagination pagination={pagination} onPageChange={handlePageChange} loading={loading} />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NPCCard.tsx
+++ b/src/components/NPCCard.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EldenRingNPC } from "@/lib/types";
+import Image from "next/image";
+
+interface NPCCardProps {
+  npc: EldenRingNPC;
+}
+
+export function NPCCard({ npc }: NPCCardProps) {
+  const { name, image, quote, location, role } = npc;
+
+  return (
+    <Card className="group overflow-hidden border-border/50 bg-card/80 backdrop-blur-sm transition-all duration-300 hover:border-golden/50 hover:bg-card/90 hover:shadow-lg hover:shadow-golden/20">
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <Image
+          src={image}
+          alt={name}
+          fill
+          className="object-cover transition-transform duration-300 group-hover:scale-105"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-transparent to-transparent" />
+        <div className="absolute bottom-2 left-2">
+          <Badge variant="outline" className="bg-muted/50 text-foreground text-xs">
+            {location}
+          </Badge>
+        </div>
+      </div>
+
+      <CardHeader className="pb-3">
+        <CardTitle className="font-medieval text-lg text-golden-light group-hover:text-golden transition-colors line-clamp-1">
+          {name}
+        </CardTitle>
+        {quote && (
+          <CardDescription className="text-muted-foreground leading-relaxed line-clamp-2">
+            {quote}
+          </CardDescription>
+        )}
+      </CardHeader>
+
+      <CardContent className="pt-0">
+        <Badge variant="outline" className="bg-muted/50 text-foreground text-xs">
+          {role}
+        </Badge>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,6 +23,11 @@ export function Navigation() {
                   Weapons
                 </Button>
               </Link>
+              <Link href="/npcs">
+                <Button variant="ghost" className="text-foreground hover:text-golden hover:bg-golden/10">
+                  NPCs
+                </Button>
+              </Link>
               <Button variant="ghost" disabled className="text-muted-foreground">
                 Bosses
               </Button>

--- a/src/components/NpcsFilters.tsx
+++ b/src/components/NpcsFilters.tsx
@@ -1,0 +1,28 @@
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+
+interface NpcsFiltersProps {
+  search: string;
+  setSearch: (search: string) => void;
+  totalItems: number;
+}
+
+export function NpcsFilters({ search, setSearch, totalItems }: NpcsFiltersProps) {
+  return (
+    <div className="flex flex-col sm:flex-row gap-4 mb-6">
+      <div className="flex-1">
+        <Input
+          placeholder="Search NPCs..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="bg-background/50 border-border/50 focus:border-golden/50"
+        />
+      </div>
+      <div className="flex items-center">
+        <Badge variant="outline" className="bg-muted/50 text-foreground">
+          {totalItems} NPCs
+        </Badge>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NpcsPagination.tsx
+++ b/src/components/NpcsPagination.tsx
@@ -1,0 +1,123 @@
+import { Button } from "@/components/ui/button";
+import { PaginationInfo } from "@/lib/types";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface NpcsPaginationProps {
+  pagination: PaginationInfo;
+  onPageChange: (page: number) => void;
+  loading: boolean;
+}
+
+export function NpcsPagination({ pagination, onPageChange, loading }: NpcsPaginationProps) {
+  const { currentPage, totalPages, totalItems, itemsPerPage } = pagination;
+
+  if (totalPages <= 1) return null;
+
+  const startItem = (currentPage - 1) * itemsPerPage + 1;
+  const endItem = Math.min(currentPage * itemsPerPage, totalItems);
+
+  const generatePageNumbers = () => {
+    const pages = [] as number[];
+    const maxVisiblePages = 5;
+
+    let startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2));
+    const endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
+
+    if (endPage - startPage < maxVisiblePages - 1) {
+      startPage = Math.max(1, endPage - maxVisiblePages + 1);
+    }
+
+    for (let i = startPage; i <= endPage; i++) {
+      pages.push(i);
+    }
+
+    return pages;
+  };
+
+  const pageNumbers = generatePageNumbers();
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mt-8">
+      <div className="text-sm text-muted-foreground">
+        Showing {startItem}-{endItem} of {totalItems} NPCs
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage <= 1 || loading}
+          className="border-border/50 hover:border-golden/50"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          Previous
+        </Button>
+
+        <div className="flex items-center gap-1">
+          {pageNumbers[0] > 1 && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(1)}
+                disabled={loading}
+                className="border-border/50 hover:border-golden/50"
+              >
+                1
+              </Button>
+              {pageNumbers[0] > 2 && (
+                <span className="px-2 text-muted-foreground">...</span>
+              )}
+            </>
+          )}
+
+          {pageNumbers.map((page) => (
+            <Button
+              key={page}
+              variant={page === currentPage ? "default" : "outline"}
+              size="sm"
+              onClick={() => onPageChange(page)}
+              disabled={loading}
+              className={
+                page === currentPage
+                  ? "bg-golden hover:bg-golden-dark text-background"
+                  : "border-border/50 hover:border-golden/50"
+              }
+            >
+              {page}
+            </Button>
+          ))}
+
+          {pageNumbers[pageNumbers.length - 1] < totalPages && (
+            <>
+              {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
+                <span className="px-2 text-muted-foreground">...</span>
+              )}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(totalPages)}
+                disabled={loading}
+                className="border-border/50 hover:border-golden/50"
+              >
+                {totalPages}
+              </Button>
+            </>
+          )}
+        </div>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage >= totalPages || loading}
+          className="border-border/50 hover:border-golden/50"
+        >
+          Next
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useEldenRingNPCs.ts
+++ b/src/hooks/useEldenRingNPCs.ts
@@ -1,0 +1,80 @@
+import { useState, useEffect } from "react";
+import { EldenRingNPC, PaginationInfo } from "@/lib/types";
+
+interface UseNPCsParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+}
+
+interface UseNPCsResult {
+  npcs: EldenRingNPC[];
+  loading: boolean;
+  error: string | null;
+  pagination: PaginationInfo;
+}
+
+export function useEldenRingNPCs(params: UseNPCsParams = {}): UseNPCsResult {
+  const { page = 0, limit = 20, search } = params;
+
+  const [npcs, setNpcs] = useState<EldenRingNPC[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState<PaginationInfo>({
+    currentPage: 1,
+    totalItems: 0,
+    itemsPerPage: limit,
+    totalPages: 0,
+  });
+
+  useEffect(() => {
+    const fetchNPCs = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const params = new URLSearchParams({
+          limit: limit.toString(),
+          page: page.toString(),
+        });
+        if (search) {
+          params.append("name", search);
+        }
+
+        const response = await fetch(`https://eldenring.fanapis.com/api/npcs?${params}`);
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch NPCs");
+        }
+
+        const data = await response.json();
+
+        if (data.success && data.data) {
+          setNpcs(data.data);
+          const totalItems = data.total || data.count;
+          setPagination({
+            currentPage: page + 1,
+            totalItems,
+            itemsPerPage: limit,
+            totalPages: Math.ceil(totalItems / limit),
+          });
+        } else {
+          throw new Error("Invalid response format");
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An error occurred");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNPCs();
+  }, [page, limit, search]);
+
+  return {
+    npcs,
+    loading,
+    error,
+    pagination,
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,17 @@ export interface EldenRingWeapon {
 
 export type EldenRingWeaponsResponse = EldenRingApiResponse<EldenRingWeapon>;
 
+export interface EldenRingNPC {
+  id: string;
+  name: string;
+  image: string;
+  quote: string | null;
+  location: string;
+  role: string;
+}
+
+export type EldenRingNPCsResponse = EldenRingApiResponse<EldenRingNPC>;
+
 export interface PaginationInfo {
   currentPage: number;
   totalItems: number;


### PR DESCRIPTION
## Summary
- add NPC hook with pagination
- create NPCCard and filter/pagination components
- implement `/npcs` page
- link NPCs in navigation
- document NPC features in README
- add tests for useEldenRingNPCs hook

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6844d6ddf0708327a79fb87ea5045267