### PR TITLE
Add Sorceries section

### DIFF
--- a/__tests__/useEldenRingSorceries.test.ts
+++ b/__tests__/useEldenRingSorceries.test.ts
@@ -1,0 +1,34 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEldenRingSorceries } from '@/hooks/useEldenRingSorceries';
+
+const mockSorceries = [
+  { id: 's1', name: 'Magic 1' },
+  { id: 's2', name: 'Magic 2' },
+];
+
+describe('useEldenRingSorceries', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: mockSorceries, total: 4 }),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns paginated sorcery data', async () => {
+    const { result } = renderHook(() => useEldenRingSorceries({ page: 1, limit: 2 }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.sorceries).toEqual(mockSorceries);
+    expect(result.current.pagination).toEqual({
+      currentPage: 2,
+      totalItems: 4,
+      itemsPerPage: 2,
+      totalPages: 2,
+    });
+  });
+});

--- a/src/app/sorceries/page.tsx
+++ b/src/app/sorceries/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { SorceryCard } from "@/components/SorceryCard";
+import { LoadingCard } from "@/components/LoadingCard";
+import { SorceriesFilters } from "@/components/SorceriesFilters";
+import { WeaponsPagination } from "@/components/WeaponsPagination";
+import { useEldenRingSorceries } from "@/hooks/useEldenRingSorceries";
+
+export default function SorceriesPage() {
+  const [page, setPage] = useState(0);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(0);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const { sorceries, loading, error, pagination } = useEldenRingSorceries({
+    page,
+    limit: 16,
+    search: debouncedSearch || undefined,
+  });
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage - 1);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center -mt-20 pt-20">
+        <div className="text-center">
+          <h1 className="text-2xl font-medieval text-destructive mb-4">Error</h1>
+          <p className="text-muted-foreground">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background -mt-20 pt-20">
+      <div className="relative py-16 px-6">
+        <div className="absolute inset-0 bg-gradient-to-b from-background via-background/95 to-background/80" />
+        <div className="relative mx-auto max-w-7xl text-center">
+          <h1 className="font-medieval text-4xl md:text-6xl text-golden-light mb-4">
+            Mystical Sorceries
+          </h1>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
+            Harness the arcane arts and bend reality to your will. Master these sorceries to overcome any foe.
+          </p>
+        </div>
+      </div>
+
+      <div className="px-6 pb-16">
+        <div className="mx-auto max-w-7xl">
+          <SorceriesFilters search={search} setSearch={setSearch} totalItems={pagination.totalItems} />
+
+          {loading ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {Array.from({ length: 16 }).map((_, i) => (
+                <LoadingCard key={i} />
+              ))}
+            </div>
+          ) : sorceries.length === 0 ? (
+            <div className="text-center py-16">
+              <h3 className="text-xl font-medieval text-muted-foreground mb-2">No sorceries found</h3>
+              <p className="text-muted-foreground">Try adjusting your search criteria.</p>
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {sorceries.map((sorcery) => (
+                  <SorceryCard key={sorcery.id} sorcery={sorcery} />
+                ))}
+              </div>
+
+              <WeaponsPagination pagination={pagination} onPageChange={handlePageChange} loading={loading} />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,6 +23,11 @@ export function Navigation() {
                   Weapons
                 </Button>
               </Link>
+              <Link href="/sorceries">
+                <Button variant="ghost" className="text-foreground hover:text-golden hover:bg-golden/10">
+                  Sorceries
+                </Button>
+              </Link>
               <Button variant="ghost" disabled className="text-muted-foreground">
                 Bosses
               </Button>

--- a/src/components/SorceriesFilters.tsx
+++ b/src/components/SorceriesFilters.tsx
@@ -1,0 +1,29 @@
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+
+interface SorceriesFiltersProps {
+  search: string;
+  setSearch: (search: string) => void;
+  totalItems: number;
+}
+
+export function SorceriesFilters({ search, setSearch, totalItems }: SorceriesFiltersProps) {
+  return (
+    <div className="flex flex-col sm:flex-row gap-4 mb-6">
+      <div className="flex-1">
+        <Input
+          placeholder="Search sorceries..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="bg-background/50 border-border/50 focus:border-golden/50"
+        />
+      </div>
+
+      <div className="flex items-center">
+        <Badge variant="outline" className="bg-muted/50 text-foreground">
+          {totalItems} sorceries
+        </Badge>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SorceryCard.tsx
+++ b/src/components/SorceryCard.tsx
@@ -1,0 +1,61 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EldenRingSorcery } from "@/lib/types";
+import Image from "next/image";
+
+interface SorceryCardProps {
+  sorcery: EldenRingSorcery;
+}
+
+export function SorceryCard({ sorcery }: SorceryCardProps) {
+  const { name, image, description, cost, slots, effects, requires } = sorcery;
+
+  return (
+    <Card className="group overflow-hidden border-border/50 bg-card/80 backdrop-blur-sm transition-all duration-300 hover:border-golden/50 hover:bg-card/90 hover:shadow-lg hover:shadow-golden/20">
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <Image
+          src={image}
+          alt={name}
+          fill
+          className="object-contain transition-transform duration-300 group-hover:scale-105 p-4"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-background/80 via-transparent to-transparent" />
+        <div className="absolute bottom-2 left-2 flex gap-2">
+          <Badge className="bg-golden text-background font-bold">{cost} FP</Badge>
+          <Badge variant="outline" className="bg-background/80 text-foreground font-mono text-xs">
+            {slots} Slot{slots > 1 ? "s" : ""}
+          </Badge>
+        </div>
+      </div>
+
+      <CardHeader className="pb-3">
+        <CardTitle className="font-medieval text-lg text-golden-light group-hover:text-golden transition-colors line-clamp-1">
+          {name}
+        </CardTitle>
+        <CardDescription className="text-muted-foreground leading-relaxed text-sm line-clamp-2">
+          {description}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="pt-0 space-y-3">
+        <div>
+          <h4 className="text-xs font-semibold text-muted-foreground mb-2">EFFECT</h4>
+          <p className="text-sm text-muted-foreground line-clamp-2">{effects}</p>
+        </div>
+        {requires.length > 0 && (
+          <div>
+            <h4 className="text-xs font-semibold text-muted-foreground mb-2">REQUIRES</h4>
+            <div className="flex gap-1 flex-wrap">
+              {requires.map((req, index) => (
+                <Badge key={index} variant="outline" className="bg-muted/50 text-foreground text-xs font-mono">
+                  {req.name}: {req.amount}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useEldenRingSorceries.ts
+++ b/src/hooks/useEldenRingSorceries.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect } from "react";
+import { EldenRingSorcery, PaginationInfo } from "@/lib/types";
+
+interface UseSorceriesParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+}
+
+interface UseSorceriesResult {
+  sorceries: EldenRingSorcery[];
+  loading: boolean;
+  error: string | null;
+  pagination: PaginationInfo;
+}
+
+export function useEldenRingSorceries(params: UseSorceriesParams = {}): UseSorceriesResult {
+  const { page = 0, limit = 20, search } = params;
+  const [sorceries, setSorceries] = useState<EldenRingSorcery[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pagination, setPagination] = useState<PaginationInfo>({
+    currentPage: 1,
+    totalItems: 0,
+    itemsPerPage: limit,
+    totalPages: 0,
+  });
+
+  useEffect(() => {
+    const fetchSorceries = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const params = new URLSearchParams({ limit: limit.toString(), page: page.toString() });
+        if (search) {
+          params.append("name", search);
+        }
+        const response = await fetch(`https://eldenring.fanapis.com/api/sorceries?${params}`);
+        if (!response.ok) {
+          throw new Error("Failed to fetch sorceries");
+        }
+        const data = await response.json();
+        if (data.success && data.data) {
+          setSorceries(data.data);
+          const total = data.total || data.count;
+          setPagination({
+            currentPage: page + 1,
+            totalItems: total,
+            itemsPerPage: limit,
+            totalPages: Math.ceil(total / limit),
+          });
+        } else {
+          throw new Error("Invalid response format");
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An error occurred");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSorceries();
+  }, [page, limit, search]);
+
+  return { sorceries, loading, error, pagination };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,23 @@ export interface EldenRingWeapon {
 
 export type EldenRingWeaponsResponse = EldenRingApiResponse<EldenRingWeapon>;
 
+export interface EldenRingSorcery {
+  id: string;
+  name: string;
+  image: string;
+  description: string;
+  type: string;
+  cost: number;
+  slots: number;
+  effects: string;
+  requires: Array<{
+    name: string;
+    amount: number;
+  }>;
+}
+
+export type EldenRingSorceriesResponse = EldenRingApiResponse<EldenRingSorcery>;
+
 export interface PaginationInfo {
   currentPage: number;
   totalItems: number;


### PR DESCRIPTION
## Summary
- add link to Sorceries in navigation bar
- define sorcery types
- create hook `useEldenRingSorceries`
- implement `SorceryCard` and filter components
- add /sorceries page
- add unit test for new hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d6f35f688327a2578c6c33ea786c