### PR TITLE
Remove EldenRing prefix from types

### DIFF
--- a/__tests__/useEldenRingAPI.test.ts
+++ b/__tests__/useEldenRingAPI.test.ts
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { useEldenRingAPI } from '@/hooks/useEldenRingAPI';
-import { EldenRingLocation } from '@/lib/types';
+import { Location } from '@/lib/types';
 
-const mockLocations: EldenRingLocation[] = [
+const mockLocations: Location[] = [
   { id: 'loc1', name: 'Stormveil Castle', image: 'img.png', region: 'Limgrave', description: 'test' },
 ];
 
@@ -19,7 +19,7 @@ describe('useEldenRingAPI', () => {
   });
 
   it('fetches locations data', async () => {
-    const { result } = renderHook(() => useEldenRingAPI<EldenRingLocation>('locations'));
+    const { result } = renderHook(() => useEldenRingAPI<Location>('locations'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 

--- a/__tests__/useEldenRingCreatures.test.ts
+++ b/__tests__/useEldenRingCreatures.test.ts
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { useEldenRingAPI } from '@/hooks/useEldenRingAPI';
-import { EldenRingCreature } from '@/lib/types';
+import { Creature } from '@/lib/types';
 
-const mockCreatures: EldenRingCreature[] = [
+const mockCreatures: Creature[] = [
   { id: 'c1', name: 'Rat', image: '', description: '', location: 'Sewer', drops: [] },
   { id: 'c2', name: 'Wolf', image: '', description: '', location: 'Forest', drops: ['Fur'] },
 ];
@@ -20,7 +20,7 @@ describe('useEldenRingAPI - creatures', () => {
   });
 
   it('fetches creatures data', async () => {
-    const { result } = renderHook(() => useEldenRingAPI<EldenRingCreature>('creatures'));
+    const { result } = renderHook(() => useEldenRingAPI<Creature>('creatures'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 

--- a/__tests__/useEldenRingItems.test.ts
+++ b/__tests__/useEldenRingItems.test.ts
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { useEldenRingAPI } from '@/hooks/useEldenRingAPI';
-import { EldenRingItem } from '@/lib/types';
+import { Item } from '@/lib/types';
 
-const mockItems: EldenRingItem[] = [
+const mockItems: Item[] = [
   { id: 'i1', name: 'Item 1', image: '', description: '', type: 'Reusable', effect: 'Effect' },
   { id: 'i2', name: 'Item 2', image: '', description: '', type: 'Key Item', effect: 'Effect' },
 ];
@@ -20,7 +20,7 @@ describe('useEldenRingAPI - items', () => {
   });
 
   it('fetches items data', async () => {
-    const { result } = renderHook(() => useEldenRingAPI<EldenRingItem>('items'));
+    const { result } = renderHook(() => useEldenRingAPI<Item>('items'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 

--- a/src/app/ashes/page.tsx
+++ b/src/app/ashes/page.tsx
@@ -2,11 +2,11 @@
 
 import { AshCard } from "@/components/AshCard";
 import { LoadingCard } from "@/components/LoadingCard";
-import { EldenRingAsh } from "@/lib/types";
+import { Ash } from "@/lib/types";
 import { useEldenRingAPI } from "@/hooks/useEldenRingAPI";
 
 export default function AshesPage() {
-  const { data: ashes, loading, error } = useEldenRingAPI<EldenRingAsh>("ashes");
+  const { data: ashes, loading, error } = useEldenRingAPI<Ash>("ashes");
 
   if (error) {
     return (

--- a/src/app/bosses/page.tsx
+++ b/src/app/bosses/page.tsx
@@ -2,11 +2,11 @@
 
 import { BossCard } from "@/components/BossCard";
 import { LoadingCard } from "@/components/LoadingCard";
-import { EldenRingBoss } from "@/lib/types";
+import { Boss } from "@/lib/types";
 import { useEldenRingAPI } from "@/hooks/useEldenRingAPI";
 
 export default function BossesPage() {
-  const { data: bosses, loading, error } = useEldenRingAPI<EldenRingBoss>("bosses");
+  const { data: bosses, loading, error } = useEldenRingAPI<Boss>("bosses");
 
   if (error) {
     return (

--- a/src/app/classes/page.tsx
+++ b/src/app/classes/page.tsx
@@ -2,11 +2,11 @@
 
 import { ClassCard } from "@/components/ClassCard";
 import { LoadingCard } from "@/components/LoadingCard";
-import { EldenRingClass } from "@/lib/types";
+import { Class } from "@/lib/types";
 import { useEldenRingAPI } from "@/hooks/useEldenRingAPI";
 
 export default function ClassesPage() {
-  const { data: classes, loading, error } = useEldenRingAPI<EldenRingClass>("classes");
+  const { data: classes, loading, error } = useEldenRingAPI<Class>("classes");
 
   if (error) {
     return (

--- a/src/app/creatures/page.tsx
+++ b/src/app/creatures/page.tsx
@@ -2,11 +2,11 @@
 
 import { CreatureCard } from "@/components/CreatureCard";
 import { LoadingCard } from "@/components/LoadingCard";
-import { EldenRingCreature } from "@/lib/types";
+import { Creature } from "@/lib/types";
 import { useEldenRingAPI } from "@/hooks/useEldenRingAPI";
 
 export default function CreaturesPage() {
-  const { data: creatures, loading, error } = useEldenRingAPI<EldenRingCreature>("creatures");
+  const { data: creatures, loading, error } = useEldenRingAPI<Creature>("creatures");
 
   if (error) {
     return (

--- a/src/app/items/page.tsx
+++ b/src/app/items/page.tsx
@@ -2,11 +2,11 @@
 
 import { ItemCard } from "@/components/ItemCard";
 import { LoadingCard } from "@/components/LoadingCard";
-import { EldenRingItem } from "@/lib/types";
+import { Item } from "@/lib/types";
 import { useEldenRingAPI } from "@/hooks/useEldenRingAPI";
 
 export default function ItemsPage() {
-  const { data: items, loading, error } = useEldenRingAPI<EldenRingItem>("items");
+  const { data: items, loading, error } = useEldenRingAPI<Item>("items");
 
   if (error) {
     return (

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -2,11 +2,11 @@
 
 import { LocationCard } from "@/components/LocationCard";
 import { LoadingCard } from "@/components/LoadingCard";
-import { EldenRingLocation } from "@/lib/types";
+import { Location } from "@/lib/types";
 import { useEldenRingAPI } from "@/hooks/useEldenRingAPI";
 
 export default function LocationsPage() {
-  const { data: locations, loading, error } = useEldenRingAPI<EldenRingLocation>("locations");
+  const { data: locations, loading, error } = useEldenRingAPI<Location>("locations");
 
   if (error) {
     return (

--- a/src/components/AmmoCard.tsx
+++ b/src/components/AmmoCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingAmmo } from "@/lib/types";
+import { Ammo } from "@/lib/types";
 import Image from "next/image";
 
 interface AmmoCardProps {
-  ammo: EldenRingAmmo;
+  ammo: Ammo;
 }
 
 export function AmmoCard({ ammo }: AmmoCardProps) {

--- a/src/components/ArmorCard.tsx
+++ b/src/components/ArmorCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
-import { EldenRingArmor } from "@/lib/types";
+import { Armor } from "@/lib/types";
 
 interface ArmorCardProps {
-  armor: EldenRingArmor;
+  armor: Armor;
 }
 
 export function ArmorCard({ armor }: ArmorCardProps) {

--- a/src/components/AshCard.tsx
+++ b/src/components/AshCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingAsh } from "@/lib/types";
+import { Ash } from "@/lib/types";
 import Image from "next/image";
 
 interface AshCardProps {
-  ash: EldenRingAsh;
+  ash: Ash;
 }
 
 export function AshCard({ ash }: AshCardProps) {

--- a/src/components/BossCard.tsx
+++ b/src/components/BossCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingBoss } from "@/lib/types";
+import { Boss } from "@/lib/types";
 import Image from "next/image";
 
 interface BossCardProps {
-  boss: EldenRingBoss;
+  boss: Boss;
 }
 
 export function BossCard({ boss }: BossCardProps) {

--- a/src/components/ClassCard.tsx
+++ b/src/components/ClassCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingClass } from "@/lib/types";
+import { Class } from "@/lib/types";
 import Image from "next/image";
 
 interface ClassCardProps {
-  eldenClass: EldenRingClass;
+  eldenClass: Class;
 }
 
 export function ClassCard({ eldenClass }: ClassCardProps) {

--- a/src/components/CreatureCard.tsx
+++ b/src/components/CreatureCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingCreature } from "@/lib/types";
+import { Creature } from "@/lib/types";
 import Image from "next/image";
 
 interface CreatureCardProps {
-  creature: EldenRingCreature;
+  creature: Creature;
 }
 
 export function CreatureCard({ creature }: CreatureCardProps) {

--- a/src/components/IncantationCard.tsx
+++ b/src/components/IncantationCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingIncantation } from "@/lib/types";
+import { Incantation } from "@/lib/types";
 import Image from "next/image";
 
 interface IncantationCardProps {
-  incantation: EldenRingIncantation;
+  incantation: Incantation;
 }
 
 export function IncantationCard({ incantation }: IncantationCardProps) {

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingItem } from "@/lib/types";
+import { Item } from "@/lib/types";
 import Image from "next/image";
 
 interface ItemCardProps {
-  item: EldenRingItem;
+  item: Item;
 }
 
 export function ItemCard({ item }: ItemCardProps) {

--- a/src/components/LocationCard.tsx
+++ b/src/components/LocationCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingLocation } from "@/lib/types";
+import { Location } from "@/lib/types";
 import Image from "next/image";
 
 interface LocationCardProps {
-  location: EldenRingLocation;
+  location: Location;
 }
 
 export function LocationCard({ location }: LocationCardProps) {

--- a/src/components/NPCCard.tsx
+++ b/src/components/NPCCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingNPC } from "@/lib/types";
+import { NPC } from "@/lib/types";
 import Image from "next/image";
 
 interface NPCCardProps {
-  npc: EldenRingNPC;
+  npc: NPC;
 }
 
 export function NPCCard({ npc }: NPCCardProps) {

--- a/src/components/SorceryCard.tsx
+++ b/src/components/SorceryCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingSorcery } from "@/lib/types";
+import { Sorcery } from "@/lib/types";
 import Image from "next/image";
 
 interface SorceryCardProps {
-  sorcery: EldenRingSorcery;
+  sorcery: Sorcery;
 }
 
 export function SorceryCard({ sorcery }: SorceryCardProps) {

--- a/src/components/TalismanCard.tsx
+++ b/src/components/TalismanCard.tsx
@@ -1,9 +1,9 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { EldenRingTalisman } from "@/lib/types";
+import { Talisman } from "@/lib/types";
 import Image from "next/image";
 
 interface TalismanCardProps {
-  talisman: EldenRingTalisman;
+  talisman: Talisman;
 }
 
 export function TalismanCard({ talisman }: TalismanCardProps) {

--- a/src/components/WeaponCard.tsx
+++ b/src/components/WeaponCard.tsx
@@ -1,10 +1,10 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { EldenRingWeapon } from "@/lib/types";
+import { Weapon } from "@/lib/types";
 import Image from "next/image";
 
 interface WeaponCardProps {
-  weapon: EldenRingWeapon;
+  weapon: Weapon;
 }
 
 export function WeaponCard({ weapon }: WeaponCardProps) {

--- a/src/hooks/useEldenRingAmmo.ts
+++ b/src/hooks/useEldenRingAmmo.ts
@@ -1,14 +1,14 @@
 import { useState, useEffect } from "react";
-import { EldenRingAmmo } from "@/lib/types";
+import { Ammo } from "@/lib/types";
 
 interface UseAmmoResult {
-  ammos: EldenRingAmmo[];
+  ammos: Ammo[];
   loading: boolean;
   error: string | null;
 }
 
 export function useEldenRingAmmo(search: string = ""): UseAmmoResult {
-  const [ammos, setAmmos] = useState<EldenRingAmmo[]>([]);
+  const [ammos, setAmmos] = useState<Ammo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/hooks/useEldenRingArmors.ts
+++ b/src/hooks/useEldenRingArmors.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import { EldenRingArmor, PaginationInfo } from "@/lib/types";
+import { Armor, PaginationInfo } from "@/lib/types";
 
 interface UseArmorsResult {
-  armors: EldenRingArmor[];
+  armors: Armor[];
   loading: boolean;
   error: string | null;
   pagination: PaginationInfo;
@@ -18,7 +18,7 @@ interface UseArmorsParams {
 }
 
 export function useEldenRingArmors(params: UseArmorsParams = {}): UseArmorsResult {
-  const [armors, setArmors] = useState<EldenRingArmor[]>([]);
+  const [armors, setArmors] = useState<Armor[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [categories, setCategories] = useState<string[]>([]);
@@ -43,7 +43,7 @@ export function useEldenRingArmors(params: UseArmorsParams = {}): UseArmorsResul
         const data = await response.json();
         if (data.success && data.data) {
           const uniqueCategories = Array.from(
-            new Set(data.data.map((armor: EldenRingArmor) => armor.category))
+            new Set(data.data.map((armor: Armor) => armor.category))
           ).filter(Boolean).sort() as string[];
           setCategories(uniqueCategories);
         }
@@ -79,7 +79,7 @@ export function useEldenRingArmors(params: UseArmorsParams = {}): UseArmorsResul
           let filteredArmors = data.data;
           if (category && category !== "all") {
             filteredArmors = filteredArmors.filter(
-              (armor: EldenRingArmor) => armor.category === category
+              (armor: Armor) => armor.category === category
             );
           }
           const shouldPaginateClient = (category && category !== "all") || !!search;

--- a/src/hooks/useEldenRingIncantations.ts
+++ b/src/hooks/useEldenRingIncantations.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import { EldenRingIncantation, PaginationInfo } from "@/lib/types";
+import { Incantation, PaginationInfo } from "@/lib/types";
 
 interface UseIncantationsResult {
-  incantations: EldenRingIncantation[];
+  incantations: Incantation[];
   loading: boolean;
   error: string | null;
   pagination: PaginationInfo;
@@ -17,7 +17,7 @@ interface UseIncantationsParams {
 export function useEldenRingIncantations(
   params: UseIncantationsParams = {}
 ): UseIncantationsResult {
-  const [incantations, setIncantations] = useState<EldenRingIncantation[]>([]);
+  const [incantations, setIncantations] = useState<Incantation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pagination, setPagination] = useState<PaginationInfo>({

--- a/src/hooks/useEldenRingNPCs.ts
+++ b/src/hooks/useEldenRingNPCs.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { EldenRingNPC, PaginationInfo } from "@/lib/types";
+import { NPC, PaginationInfo } from "@/lib/types";
 
 interface UseNPCsParams {
   page?: number;
@@ -8,7 +8,7 @@ interface UseNPCsParams {
 }
 
 interface UseNPCsResult {
-  npcs: EldenRingNPC[];
+  npcs: NPC[];
   loading: boolean;
   error: string | null;
   pagination: PaginationInfo;
@@ -17,7 +17,7 @@ interface UseNPCsResult {
 export function useEldenRingNPCs(params: UseNPCsParams = {}): UseNPCsResult {
   const { page = 0, limit = 20, search } = params;
 
-  const [npcs, setNpcs] = useState<EldenRingNPC[]>([]);
+  const [npcs, setNpcs] = useState<NPC[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pagination, setPagination] = useState<PaginationInfo>({

--- a/src/hooks/useEldenRingShields.ts
+++ b/src/hooks/useEldenRingShields.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import { EldenRingWeapon as EldenRingShield, PaginationInfo } from "@/lib/types";
+import { Weapon as Shield, PaginationInfo } from "@/lib/types";
 
 interface UseShieldsResult {
-  shields: EldenRingShield[];
+  shields: Shield[];
   loading: boolean;
   error: string | null;
   pagination: PaginationInfo;
@@ -18,7 +18,7 @@ interface UseShieldsParams {
 }
 
 export function useEldenRingShields(params: UseShieldsParams = {}): UseShieldsResult {
-  const [shields, setShields] = useState<EldenRingShield[]>([]);
+  const [shields, setShields] = useState<Shield[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [categories, setCategories] = useState<string[]>([]);
@@ -46,7 +46,7 @@ export function useEldenRingShields(params: UseShieldsParams = {}): UseShieldsRe
 
         if (data.success && data.data) {
           const uniqueCategories = Array.from(
-            new Set(data.data.map((shield: EldenRingShield) => shield.category))
+            new Set(data.data.map((shield: Shield) => shield.category))
           ).filter(Boolean).sort() as string[];
 
           setCategories(uniqueCategories);
@@ -89,7 +89,7 @@ export function useEldenRingShields(params: UseShieldsParams = {}): UseShieldsRe
           let filtered = data.data;
           if (category && category !== "all") {
             filtered = filtered.filter(
-              (shield: EldenRingShield) => shield.category === category
+              (shield: Shield) => shield.category === category
             );
           }
 

--- a/src/hooks/useEldenRingSorceries.ts
+++ b/src/hooks/useEldenRingSorceries.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { EldenRingSorcery, PaginationInfo } from "@/lib/types";
+import { Sorcery, PaginationInfo } from "@/lib/types";
 
 interface UseSorceriesParams {
   page?: number;
@@ -8,7 +8,7 @@ interface UseSorceriesParams {
 }
 
 interface UseSorceriesResult {
-  sorceries: EldenRingSorcery[];
+  sorceries: Sorcery[];
   loading: boolean;
   error: string | null;
   pagination: PaginationInfo;
@@ -16,7 +16,7 @@ interface UseSorceriesResult {
 
 export function useEldenRingSorceries(params: UseSorceriesParams = {}): UseSorceriesResult {
   const { page = 0, limit = 20, search } = params;
-  const [sorceries, setSorceries] = useState<EldenRingSorcery[]>([]);
+  const [sorceries, setSorceries] = useState<Sorcery[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pagination, setPagination] = useState<PaginationInfo>({

--- a/src/hooks/useEldenRingTalismans.ts
+++ b/src/hooks/useEldenRingTalismans.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import { EldenRingTalisman, PaginationInfo } from "@/lib/types";
+import { Talisman, PaginationInfo } from "@/lib/types";
 
 interface UseTalismansResult {
-  talismans: EldenRingTalisman[];
+  talismans: Talisman[];
   loading: boolean;
   error: string | null;
   pagination: PaginationInfo;
@@ -17,7 +17,7 @@ interface UseTalismansParams {
 export function useEldenRingTalismans(
   params: UseTalismansParams = {}
 ): UseTalismansResult {
-  const [talismans, setTalismans] = useState<EldenRingTalisman[]>([]);
+  const [talismans, setTalismans] = useState<Talisman[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pagination, setPagination] = useState<PaginationInfo>({
@@ -56,7 +56,7 @@ export function useEldenRingTalismans(
         const data = await response.json();
 
         if (data.success && data.data) {
-          let filtered = data.data as EldenRingTalisman[];
+          let filtered = data.data as Talisman[];
 
           const shouldPaginateClient = !!search;
 

--- a/src/hooks/useEldenRingWeapons.ts
+++ b/src/hooks/useEldenRingWeapons.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import { EldenRingWeapon, PaginationInfo } from "@/lib/types";
+import { Weapon, PaginationInfo } from "@/lib/types";
 
 interface UseWeaponsResult {
-  weapons: EldenRingWeapon[];
+  weapons: Weapon[];
   loading: boolean;
   error: string | null;
   pagination: PaginationInfo;
@@ -18,7 +18,7 @@ interface UseWeaponsParams {
 }
 
 export function useEldenRingWeapons(params: UseWeaponsParams = {}): UseWeaponsResult {
-  const [weapons, setWeapons] = useState<EldenRingWeapon[]>([]);
+  const [weapons, setWeapons] = useState<Weapon[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [categories, setCategories] = useState<string[]>([]);
@@ -47,7 +47,7 @@ export function useEldenRingWeapons(params: UseWeaponsParams = {}): UseWeaponsRe
         
         if (data.success && data.data) {
           const uniqueCategories = Array.from(
-            new Set(data.data.map((weapon: EldenRingWeapon) => weapon.category))
+            new Set(data.data.map((weapon: Weapon) => weapon.category))
           ).filter(Boolean).sort() as string[];
           
           setCategories(uniqueCategories);
@@ -96,7 +96,7 @@ export function useEldenRingWeapons(params: UseWeaponsParams = {}): UseWeaponsRe
           // Filter by category client-side since API doesn't support category filter
           if (category && category !== "all") {
             filteredWeapons = filteredWeapons.filter(
-              (weapon: EldenRingWeapon) => weapon.category === category
+              (weapon: Weapon) => weapon.category === category
             );
           }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export interface EldenRingClass {
+export interface Class {
   id: string;
   name: string;
   image: string;
@@ -16,15 +16,15 @@ export interface EldenRingClass {
   };
 }
 
-export interface EldenRingApiResponse<T> {
+export interface ApiResponse<T> {
   success: boolean;
   count: number;
   data: T[];
 }
 
-export type EldenRingClassesResponse = EldenRingApiResponse<EldenRingClass>;
+export type ClassesResponse = ApiResponse<Class>;
 
-export interface EldenRingWeapon {
+export interface Weapon {
   id: string;
   name: string;
   image: string;
@@ -49,9 +49,9 @@ export interface EldenRingWeapon {
   weight: number;
 }
 
-export type EldenRingWeaponsResponse = EldenRingApiResponse<EldenRingWeapon>;
+export type WeaponsResponse = ApiResponse<Weapon>;
 
-export interface EldenRingItem {
+export interface Item {
   id: string;
   name: string;
   image: string;
@@ -60,7 +60,7 @@ export interface EldenRingItem {
   effect: string;
 }
 
-export interface EldenRingTalisman {
+export interface Talisman {
   id: string;
   name: string;
   image: string;
@@ -68,9 +68,9 @@ export interface EldenRingTalisman {
   effect: string;
 }
 
-export type EldenRingTalismansResponse = EldenRingApiResponse<EldenRingTalisman>;
+export type TalismansResponse = ApiResponse<Talisman>;
 
-export interface EldenRingArmor {
+export interface Armor {
   id: string;
   name: string;
   image: string;
@@ -87,9 +87,9 @@ export interface EldenRingArmor {
   weight: number;
 }
 
-export type EldenRingArmorsResponse = EldenRingApiResponse<EldenRingArmor>;
+export type ArmorsResponse = ApiResponse<Armor>;
 
-export interface EldenRingCreature {
+export interface Creature {
   id: string;
   name: string;
   image: string;
@@ -98,9 +98,9 @@ export interface EldenRingCreature {
   drops: string[];
 }
 
-export type EldenRingCreaturesResponse = EldenRingApiResponse<EldenRingCreature>;
+export type CreaturesResponse = ApiResponse<Creature>;
 
-export interface EldenRingIncantation {
+export interface Incantation {
   id: string;
   name: string;
   image: string;
@@ -115,9 +115,9 @@ export interface EldenRingIncantation {
   }>;
 }
 
-export type EldenRingIncantationsResponse = EldenRingApiResponse<EldenRingIncantation>;
+export type IncantationsResponse = ApiResponse<Incantation>;
 
-export interface EldenRingSorcery {
+export interface Sorcery {
   id: string;
   name: string;
   image: string;
@@ -132,9 +132,9 @@ export interface EldenRingSorcery {
   }>;
 }
 
-export type EldenRingSorceriesResponse = EldenRingApiResponse<EldenRingSorcery>;
+export type SorceriesResponse = ApiResponse<Sorcery>;
 
-export interface EldenRingLocation {
+export interface Location {
   id: string;
   name: string;
   image: string;
@@ -142,9 +142,9 @@ export interface EldenRingLocation {
   description: string;
 }
 
-export type EldenRingLocationsResponse = EldenRingApiResponse<EldenRingLocation>;
+export type LocationsResponse = ApiResponse<Location>;
 
-export interface EldenRingAmmo {
+export interface Ammo {
   id: string;
   name: string;
   image: string;
@@ -157,9 +157,9 @@ export interface EldenRingAmmo {
   passive: string;
 }
 
-export type EldenRingAmmoResponse = EldenRingApiResponse<EldenRingAmmo>;
+export type AmmoResponse = ApiResponse<Ammo>;
 
-export interface EldenRingAsh {
+export interface Ash {
   id: string;
   name: string;
   image: string;
@@ -168,9 +168,9 @@ export interface EldenRingAsh {
   skill: string;
 }
 
-export type EldenRingAshesResponse = EldenRingApiResponse<EldenRingAsh>;
+export type AshesResponse = ApiResponse<Ash>;
 
-export interface EldenRingBoss {
+export interface Boss {
   id: string;
   name: string;
   image: string | null;
@@ -181,9 +181,9 @@ export interface EldenRingBoss {
   healthPoints: string;
 }
 
-export type EldenRingBossesResponse = EldenRingApiResponse<EldenRingBoss>;
+export type BossesResponse = ApiResponse<Boss>;
 
-export interface EldenRingNPC {
+export interface NPC {
   id: string;
   name: string;
   image: string;
@@ -192,7 +192,7 @@ export interface EldenRingNPC {
   role: string;
 }
 
-export type EldenRingNPCsResponse = EldenRingApiResponse<EldenRingNPC>;
+export type NPCsResponse = ApiResponse<NPC>;
 
 export interface PaginationInfo {
   currentPage: number;


### PR DESCRIPTION
## Summary
- drop `EldenRing` prefix from all exported types
- update hooks, components and pages to use new names
- adapt tests to new types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844f34048488327a57266f4173896d4