### PR TITLE
Fix menu header padding

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -75,7 +75,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
       `}>
         <div className="flex h-full flex-col">
           {/* Header with Close Button for Mobile */}
-          <div className="flex-shrink-0 p-4 border-b border-border/50">
+          <div className="flex-shrink-0 px-6 py-4 border-b border-border/50">
             <div className="flex items-center justify-between">
               <Link href="/" className="flex items-center space-x-2" onClick={onClose}>
                 <span className="font-medieval text-lg text-golden-light">ELDEN RING</span>


### PR DESCRIPTION
## Summary
- adjust padding on sidebar header so its border line matches the main header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845af6213e883279bb462eff458f451